### PR TITLE
Change deprecated field sourceAndType to attributes

### DIFF
--- a/config/commitstatus.yaml
+++ b/config/commitstatus.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   filter:
-    sourceAndType:
+    attributes:
       type: dev.mattmoor.knobots.commitstatus
   subscriber:
     ref:

--- a/config/copyright.yaml
+++ b/config/copyright.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   filter:
-    sourceAndType:
+    attributes:
       type: dev.mattmoor.knobots.reviewrequest
   subscriber:
     ref:

--- a/config/dailybuild.yaml
+++ b/config/dailybuild.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   filter:
-    sourceAndType:
+    attributes:
       type: dev.mattmoor.knobots.dailytaskrun
   subscriber:
     ref:

--- a/config/donotsubmit.yaml
+++ b/config/donotsubmit.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   filter:
-    sourceAndType:
+    attributes:
       type: dev.mattmoor.knobots.reviewrequest
   subscriber:
     ref:

--- a/config/gotool.yaml
+++ b/config/gotool.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   filter:
-    sourceAndType:
+    attributes:
       type: dev.mattmoor.knobots.reviewrequest
   subscriber:
     ref:

--- a/config/reviewrequest.yaml
+++ b/config/reviewrequest.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   filter:
-    sourceAndType:
+    attributes:
       type: dev.knative.source.github.pull_request
   subscriber:
     ref:

--- a/config/reviewresult.yaml
+++ b/config/reviewresult.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   filter:
-    sourceAndType:
+    attributes:
       type: dev.mattmoor.knobots.reviewresult
   subscriber:
     ref:

--- a/config/slack.yaml
+++ b/config/slack.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   filter:
-    sourceAndType:
+    attributes:
       type: dev.mattmoor.knobots.slack.direct
   subscriber:
     ref:

--- a/config/sockeye.yaml
+++ b/config/sockeye.yaml
@@ -4,7 +4,6 @@ metadata:
   name: sockeye-trigger
   namespace: default
 spec:
-  filter: {}
   subscriber:
     ref:
       apiVersion: serving.knative.dev/v1

--- a/config/todo.yaml
+++ b/config/todo.yaml
@@ -5,7 +5,7 @@
 #   namespace: default
 # spec:
 #   filter:
-#     sourceAndType:
+#     attributes:
 #       type: dev.knative.source.github.pull_request
 #   subscriber:
 #     ref:
@@ -20,7 +20,7 @@
 #   namespace: default
 # spec:
 #   filter:
-#     sourceAndType:
+#     attributes:
 #       type: dev.knative.source.github.issues
 #   subscriber:
 #     ref:

--- a/config/triage.yaml
+++ b/config/triage.yaml
@@ -5,7 +5,7 @@
 #   namespace: default
 # spec:
 #   filter:
-#     sourceAndType:
+#     attributes:
 #       type: dev.knative.source.github.pull_request
 #   subscriber:
 #     ref:
@@ -20,7 +20,7 @@
 #   namespace: default
 # spec:
 #   filter:
-#     sourceAndType:
+#     attributes:
 #       type: dev.knative.source.github.issues
 #   subscriber:
 #     ref:

--- a/config/tweeter.yaml
+++ b/config/tweeter.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   filter:
-    sourceAndType:
+    attributes:
       type: dev.mattmoor.knobots.tweeter
   subscriber:
     ref:

--- a/config/typo.yaml
+++ b/config/typo.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   filter:
-    sourceAndType:
+    attributes:
       type: dev.mattmoor.knobots.reviewrequest
   subscriber:
     ref:

--- a/config/watchbuild.yaml
+++ b/config/watchbuild.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   filter:
-    sourceAndType:
+    attributes:
       type: dev.mattmoor.knobots.watchtaskrun
   subscriber:
     ref:

--- a/config/whitespace.yaml
+++ b/config/whitespace.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   filter:
-    sourceAndType:
+    attributes:
       type: dev.mattmoor.knobots.reviewrequest
   subscriber:
     ref:


### PR DESCRIPTION
The sourceAndType field has been deprecated for months, attributes is the new hotness. So use that instead.