### PR TITLE
Update goimports to exclude wire_gen.go files

### DIFF
--- a/config/templates/gotool-template.yaml
+++ b/config/templates/gotool-template.yaml
@@ -73,7 +73,7 @@ spec:
       mkdir -p ${PARENT_DIR}
       ln -s /workspace/source ${PARENT_DIR}/$(inputs.params.REPOSITORY)
       cd ${PARENT_DIR}/$(inputs.params.REPOSITORY)
-      /ko-app/goimports -w $(find -name '*.go' | grep -v vendor | grep -v third_party)
+      find -name '*.go' \! -name wire_gen.go -exec /ko-app/goimports -w {} \+ -o \( -path ./vendor -o -path ./third_party \) -prune
     env:
     - name: GOPATH
       value: /tmp/go
@@ -91,7 +91,7 @@ spec:
     - |
         Produced via:
           `gofmt -s -w $(find -path './vendor' -prune -o -path './third_party' -prune -o -type f -name '*.go' -print)`
-          `goimports -w $(find -name '*.go' | grep -v vendor | grep -v third_party)`
+          `find -name '*.go' \! -name wire_gen.go -exec goimports -w {} \+ -o \( -path ./vendor -o -path ./third_party \) -prune`
         /assign $(inputs.params.ASSIGNEE)
         /cc $(inputs.params.ASSIGNEE)
 


### PR DESCRIPTION
These files are generated by wire which does not format using goimports.